### PR TITLE
Add forge installation cache for CI builds

### DIFF
--- a/src/structure/repo/Repo.struct.ts
+++ b/src/structure/repo/Repo.struct.ts
@@ -43,4 +43,8 @@ export class RepoStructure extends BaseFileStructure {
         return join(this.absoluteRoot, 'work')
     }
 
+    public getForgeDirectory(artifactVersion: string): string {
+        return join(this.absoluteRoot, 'forge', artifactVersion)
+    }
+
 }

--- a/src/structure/spec_model/module/File.struct.ts
+++ b/src/structure/spec_model/module/File.struct.ts
@@ -3,7 +3,7 @@ import { Stats } from 'fs'
 import { Type, Module } from 'helios-distribution-types'
 import { resolve as resolveURL } from 'url'
 import { ModuleStructure } from './Module.struct'
-import { readdir, stat } from 'fs-extra'
+import { pathExists, readdir, stat } from 'fs-extra'
 import { join, resolve, sep } from 'path'
 import { MinecraftVersion } from '../../../util/MinecraftVersion'
 import { UntrackedFilesOption } from '../../../model/nebula/servermeta'
@@ -34,14 +34,16 @@ export class MiscFileStructure extends ModuleStructure {
 
     protected async recursiveModuleScan(dir: string): Promise<Module[]> {
         let acc: Module[] = []
-        const subdirs = await readdir(dir)
-        for (const file of subdirs) {
-            const filePath = resolve(dir, file)
-            const stats = await stat(filePath)
-            if (stats.isDirectory()) {
-                acc = acc.concat(await this.recursiveModuleScan(filePath))
-            } else {
-                acc.push(await this.parseModule(file, filePath, stats))
+        if (await pathExists(dir)) {
+            const subdirs = await readdir(dir)
+            for (const file of subdirs) {
+                const filePath = resolve(dir, file)
+                const stats = await stat(filePath)
+                if (stats.isDirectory()) {
+                    acc = acc.concat(await this.recursiveModuleScan(filePath))
+                } else {
+                    acc.push(await this.parseModule(file, filePath, stats))
+                }
             }
         }
         return acc


### PR DESCRIPTION
### Changes to build packs in CI

Two changes are needed to build with CI.

- The Forge 1.13+ installer displays a GUI and CI can't handle it, so you need to create a cache so you can commit the installer results to Git.
- Git can't manage empty folders, so you need to avoid accessing them.

This pull request fixes these two issues