### PR TITLE
Update servermeta.ts

### DIFF
--- a/src/model/nebula/servermeta.ts
+++ b/src/model/nebula/servermeta.ts
@@ -24,6 +24,7 @@ export function getDefaultServerMeta(id: string, version: string, options?: Serv
             version: '1.0.0',
             name: `${id} (Minecraft ${version})`,
             description: `${id} Running Minecraft ${version}`,
+            icon: 'https://YourURL.domain/CHANGE_ME.png',
             address: 'localhost:25565',
             discord: {
                 shortId: '<FILL IN OR REMOVE DISCORD OBJECT>',
@@ -64,6 +65,7 @@ export interface ServerMeta {
         version: Server['version']
         name: Server['name']
         description: Server['description']
+        icon: 'https://YourURL.domain/CHANGE_ME.png'
         address: Server['address']
         discord?: Server['discord']
         mainServer: Server['mainServer']


### PR DESCRIPTION
Adding placeholder URL for Icons to be visible in the servermeta.json to allow editing on the instance and easy transfer into distro.json especially with a large number of packs.

Just a quality of life change as you can set it on the servermeta.json and then when compiling the distro.json it is already pre-setup no need to scramble around to change it.