### PR TITLE
[Enhancement] Pull Server Icon data from servermeta.json

### DIFF
--- a/src/model/nebula/servermeta.ts
+++ b/src/model/nebula/servermeta.ts
@@ -24,6 +24,7 @@ export function getDefaultServerMeta(id: string, version: string, options?: Serv
             version: '1.0.0',
             name: `${id} (Minecraft ${version})`,
             description: `${id} Running Minecraft ${version}`,
+            icon: 'https://YourURL.domain/CHANGE_ME.png',
             address: 'localhost:25565',
             discord: {
                 shortId: '<FILL IN OR REMOVE DISCORD OBJECT>',
@@ -64,6 +65,7 @@ export interface ServerMeta {
         version: Server['version']
         name: Server['name']
         description: Server['description']
+        icon: 'https://YourURL.domain/CHANGE_ME.png'
         address: Server['address']
         discord?: Server['discord']
         mainServer: Server['mainServer']

--- a/src/structure/spec_model/Server.struct.ts
+++ b/src/structure/spec_model/Server.struct.ts
@@ -107,21 +107,6 @@ export class ServerStructure extends BaseModelStructure<Server> {
                     continue
                 }
 
-                let iconUrl: string = null!
-
-                // Resolve server icon
-                const subFiles = await readdir(absoluteServerRoot)
-                for (const subFile of subFiles) {
-                    const caseInsensitive = subFile.toLowerCase()
-                    if (caseInsensitive.endsWith('.jpg') || caseInsensitive.endsWith('.png')) {
-                        iconUrl = new URL(join(relativeServerRoot, subFile), this.baseUrl).toString()
-                    }
-                }
-
-                if (!iconUrl) {
-                    this.logger.warn(`No icon file found for server ${file}.`)
-                }
-
                 // Read server meta
                 const serverMeta: ServerMeta = JSON.parse(await readFile(resolvePath(absoluteServerRoot, this.SERVER_META_FILE), 'utf-8'))
                 const minecraftVersion = new MinecraftVersion(match[2])
@@ -176,7 +161,7 @@ export class ServerStructure extends BaseModelStructure<Server> {
                     id: match[1],
                     name: serverMeta.meta.name,
                     description: serverMeta.meta.description,
-                    icon: iconUrl,
+                    icon: serverMeta.meta.icon,
                     version: serverMeta.meta.version,
                     address: serverMeta.meta.address,
                     minecraftVersion: match[2],


### PR DESCRIPTION
Adding placeholder URL for Icons to be visible in the servermeta.json to allow editing on the instance and easy transfer into distro.json especially with a large number of packs.

Just a quality of life change as you can set it on the servermeta.json and then when compiling the distro.json it is already pre-setup no need to scramble around to change it.

(Resubmitted PR as I forgot to remove and rename a block of code)