### PR TITLE
Add 1.19's support and support Minecraft version without patch version (1.18, 1.19)

### DIFF
--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -31,7 +31,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         if(version.getMinor() === 12 && VersionUtil.isOneDotTwelveFG2(libraryVersion)) {
             return false
         }
-        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16])
+        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17])
     }
 
     private generatedFiles: GeneratedFile[] | undefined
@@ -51,20 +51,13 @@ export class ForgeGradle3Adapter extends ForgeResolver {
     }
 
     private configure(): void {
-        // Configure for 13, 14, 15, 16
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16])) {
+        // Configure for 13, 14, 15, 16, 17
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428
             const mcpUnifiedVersion = `${this.minecraftVersion}-${ForgeGradle3Adapter.WILDCARD_MCP_VERSION}`
 
             this.generatedFiles = [
-                {
-                    name: 'base jar',
-                    group: LibRepoStructure.FORGE_GROUP,
-                    artifact: LibRepoStructure.FORGE_ARTIFACT,
-                    version: this.artifactVersion,
-                    classifiers: [undefined]
-                },
                 {
                     name: 'universal jar',
                     group: LibRepoStructure.FORGE_GROUP,
@@ -99,7 +92,53 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 ForgeGradle3Adapter.WILDCARD_MCP_VERSION
             ]
 
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16])) {
+
+                // Base jar present for 1.13-1.16
+
+                this.generatedFiles.unshift(
+                    {
+                        name: 'base jar',
+                        group: LibRepoStructure.FORGE_GROUP,
+                        artifact: LibRepoStructure.FORGE_ARTIFACT,
+                        version: this.artifactVersion,
+                        classifiers: [undefined]
+                    }
+                )
+            }
+
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17])) {
+
+                // Added in 1.17+
+
+                this.generatedFiles.unshift(
+                    {
+                        name: 'fmlcore',
+                        group: LibRepoStructure.FORGE_GROUP,
+                        artifact: LibRepoStructure.FMLCORE_ARTIFACT,
+                        version: this.artifactVersion,
+                        classifiers: [undefined]
+                    },
+                    {
+                        name: 'javafmllanguage',
+                        group: LibRepoStructure.FORGE_GROUP,
+                        artifact: LibRepoStructure.JAVAFMLLANGUAGE_ARTIFACT,
+                        version: this.artifactVersion,
+                        classifiers: [undefined]
+                    },
+                    {
+                        name: 'mclanguage',
+                        group: LibRepoStructure.FORGE_GROUP,
+                        artifact: LibRepoStructure.MCLANGUAGE_ARTIFACT,
+                        version: this.artifactVersion,
+                        classifiers: [undefined]
+                    }
+                )
+            }
+
             if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15])) {
+
+                // 13, 14, 15 use just the MC version.
 
                 this.generatedFiles.push(
                     {
@@ -124,6 +163,8 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                     }
                 )
             } else {
+
+                // 16+ uses the mcp unified version.
 
                 this.generatedFiles.push(
                     {

--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -51,7 +51,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
     }
 
     private configure(): void {
-        // Configure for 13, 14, 15, 16, 17, 18
+        // Configure for 13, 14, 15, 16, 17, 18, 19
         if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18, 19])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428

--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -31,7 +31,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         if(version.getMinor() === 12 && VersionUtil.isOneDotTwelveFG2(libraryVersion)) {
             return false
         }
-        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18])
+        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18, 19])
     }
 
     private generatedFiles: GeneratedFile[] | undefined
@@ -52,7 +52,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
     private configure(): void {
         // Configure for 13, 14, 15, 16, 17, 18
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18])) {
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18, 19])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428
             const mcpUnifiedVersion = `${this.minecraftVersion}-${ForgeGradle3Adapter.WILDCARD_MCP_VERSION}`
@@ -107,7 +107,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18, 19])) {
 
                 // Added in 1.17+
 

--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -31,7 +31,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         if(version.getMinor() === 12 && VersionUtil.isOneDotTwelveFG2(libraryVersion)) {
             return false
         }
-        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17])
+        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18])
     }
 
     private generatedFiles: GeneratedFile[] | undefined
@@ -51,8 +51,8 @@ export class ForgeGradle3Adapter extends ForgeResolver {
     }
 
     private configure(): void {
-        // Configure for 13, 14, 15, 16, 17
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17])) {
+        // Configure for 13, 14, 15, 16, 17, 18
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428
             const mcpUnifiedVersion = `${this.minecraftVersion}-${ForgeGradle3Adapter.WILDCARD_MCP_VERSION}`
@@ -107,7 +107,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18])) {
 
                 // Added in 1.17+
 

--- a/src/structure/repo/LibRepo.struct.ts
+++ b/src/structure/repo/LibRepo.struct.ts
@@ -7,6 +7,9 @@ export class LibRepoStructure extends BaseMavenRepo {
 
     public static readonly FORGE_GROUP = 'net.minecraftforge'
     public static readonly FORGE_ARTIFACT = 'forge'
+    public static readonly FMLCORE_ARTIFACT = 'fmlcore'
+    public static readonly JAVAFMLLANGUAGE_ARTIFACT = 'javafmllanguage'
+    public static readonly MCLANGUAGE_ARTIFACT = 'mclanguage'
 
     constructor(
         absoluteRoot: string,

--- a/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
+++ b/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
@@ -13,7 +13,7 @@ export class ForgeModStructure113 extends BaseForgeModStructure {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16])
+        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17])
     }
 
     private forgeModMetadata: {[property: string]: ModsToml | undefined} = {}

--- a/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
+++ b/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
@@ -13,7 +13,7 @@ export class ForgeModStructure113 extends BaseForgeModStructure {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17, 18])
+        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17, 18, 19])
     }
 
     private forgeModMetadata: {[property: string]: ModsToml | undefined} = {}

--- a/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
+++ b/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
@@ -13,7 +13,7 @@ export class ForgeModStructure113 extends BaseForgeModStructure {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17])
+        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17, 18])
     }
 
     private forgeModMetadata: {[property: string]: ModsToml | undefined} = {}

--- a/src/util/MinecraftVersion.ts
+++ b/src/util/MinecraftVersion.ts
@@ -1,17 +1,17 @@
 export class MinecraftVersion {
 
-    private static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).(\d+)/
+    private static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).?(\d+)?/
 
     private readonly major: number
     private readonly minor: number
-    private readonly revision: number
+    private readonly revision: number | null
 
     constructor(version: string) {
         const res = MinecraftVersion.MINECRAFT_VERSION_REGEX.exec(version)
         if(res != null) {
             this.major = Number(res[1])
             this.minor = Number(res[2])
-            this.revision = Number(res[3])
+            this.revision = res[3] ? Number(res[3]) : null
         } else {
             throw new Error(`${version} is not a valid minecraft version!`)
         }
@@ -23,8 +23,8 @@ export class MinecraftVersion {
 
     public getMajor(): number { return this.major }
     public getMinor(): number { return this.minor }
-    public getRevision(): number { return this.revision }
+    public getRevision(): number | null { return this.revision }
 
-    public toString(): string { return `${this.major}.${this.minor}.${this.revision}`}
+    public toString(): string { return this.revision === null ? `${this.major}.${this.minor}` : `${this.major}.${this.minor}.${this.revision}`}
 
 }

--- a/src/util/versionutil.ts
+++ b/src/util/versionutil.ts
@@ -12,7 +12,7 @@ export class VersionUtil {
         'latest'
     ]
 
-    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).(\d+)/
+    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).?(\d+)?/
 
     public static isVersionAcceptable(version: MinecraftVersion, acceptable: number[]): boolean {
         if (version.getMajor() === 1) {


### PR DESCRIPTION
- Adding 1.19 support.
- Support Minecraft version without patch version like 1.18, 1.19 to avoiding : https://github.com/dscalzi/Nebula/blob/8c224e3e398d76a9514e0975e7bd04506c30141d/src/util/MinecraftVersion.ts#L16