### PR TITLE
feat: 1.20 support and allow versions without patch number

### DIFF
--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -411,7 +411,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
                 const targetLocalPath = join(
                     libDir,
-                    MavenUtil.mavenComponentsToPath(entry.group, entry.artifact, entry.version, _classifier)
+                    MavenUtil.mavenComponentsAsNormalizedPath(entry.group, entry.artifact, entry.version, _classifier)
                 )
 
                 targetLocations.push(targetLocalPath)

--- a/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
+++ b/src/resolver/forge/adapter/ForgeGradle3.resolver.ts
@@ -33,7 +33,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         if(version.getMinor() === 12 && VersionUtil.isOneDotTwelveFG2(libraryVersion)) {
             return false
         }
-        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18, 19])
+        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18, 19, 20])
     }
 
     private generatedFiles: GeneratedFile[] | undefined
@@ -57,7 +57,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         const is117OrGreater = this.minecraftVersion.getMinor() >= 17
 
         // Configure for 13, 14, 15, 16, 17, 18, 19
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18, 19])) {
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18, 19, 20])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428
             const mcpUnifiedVersion = `${this.minecraftVersion}-${ForgeGradle3Adapter.WILDCARD_MCP_VERSION}`
@@ -116,7 +116,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18, 19])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18, 19, 20])) {
 
                 // Added in 1.17+
 
@@ -145,7 +145,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if (VersionUtil.isVersionAcceptable(this.minecraftVersion, [18, 19])) {
+            if (VersionUtil.isVersionAcceptable(this.minecraftVersion, [18, 19, 20])) {
 
                 // Added in 1.18+
 
@@ -508,7 +508,6 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                         )
                     )
                 })
-
                 const destination = libRepo.getArtifactByComponents(
                     components.group,
                     components.artifact,

--- a/src/structure/repo/BaseMavenRepo.ts
+++ b/src/structure/repo/BaseMavenRepo.ts
@@ -20,21 +20,21 @@ export abstract class BaseMavenRepo extends BaseFileStructure {
     }
 
     public getArtifactById(mavenIdentifier: string, extension?: string): string {
-        return resolve(this.containerDirectory, MavenUtil.mavenIdentifierToString(mavenIdentifier, extension))
+        return resolve(this.containerDirectory, MavenUtil.mavenIdentifierAsPath(mavenIdentifier, extension))
     }
 
     public getArtifactByComponents(
         group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): string {
         return resolve(this.containerDirectory,
-            MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension))
+            MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension))
     }
 
     public getArtifactUrlByComponents(
         baseURL: string, group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): string {
         return new URL(join(this.relativeRoot,
-            MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension)), baseURL).toString()
+            MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension)), baseURL).toString()
     }
 
     public async artifactExists(path: string): Promise<boolean> {
@@ -42,14 +42,14 @@ export abstract class BaseMavenRepo extends BaseFileStructure {
     }
 
     public async downloadArtifactById(url: string, mavenIdentifier: string, extension?: string): Promise<void> {
-        return this.downloadArtifactBase(url, MavenUtil.mavenIdentifierToString(mavenIdentifier, extension) as string)
+        return this.downloadArtifactBase(url, MavenUtil.mavenIdentifierAsPath(mavenIdentifier, extension) as string)
     }
 
     public async downloadArtifactByComponents(
         url: string, group: string, artifact: string, version: string, classifier?: string, extension?: string
     ): Promise<void> {
         return this.downloadArtifactBase(url,
-            MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension))
+            MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension))
     }
 
     private async downloadArtifactBase(url: string, relative: string): Promise<void> {
@@ -75,14 +75,14 @@ export abstract class BaseMavenRepo extends BaseFileStructure {
     }
 
     public async headArtifactById(url: string, mavenIdentifier: string, extension?: string): Promise<boolean> {
-        return this.headArtifactBase(url, MavenUtil.mavenIdentifierToString(mavenIdentifier, extension) as string)
+        return this.headArtifactBase(url, MavenUtil.mavenIdentifierAsPath(mavenIdentifier, extension) as string)
     }
 
     public async headArtifactByComponents(
         url: string, group: string, artifact: string, version: string, classifier?: string, extension?: string
     ): Promise<boolean> {
         return this.headArtifactBase(url,
-            MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension))
+            MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension))
     }
 
     private async headArtifactBase(url: string, relative: string): Promise<boolean> {

--- a/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
+++ b/src/structure/spec_model/module/forgemod/ForgeMod113.struct.ts
@@ -13,7 +13,7 @@ export class ForgeModStructure113 extends BaseForgeModStructure {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17, 18, 19])
+        return VersionUtil.isVersionAcceptable(version, [13, 14, 15, 16, 17, 18, 19, 20])
     }
 
     private forgeModMetadata: {[property: string]: ModsToml | undefined} = {}

--- a/src/util/MavenUtil.ts
+++ b/src/util/MavenUtil.ts
@@ -63,7 +63,7 @@ export class MavenUtil {
     public static mavenComponentsToString(
         group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): string {
-        return `${group.replace(/\./g, '/')}/${artifact}/${version}/${artifact}-${version}${classifier != null ? `-${classifier}` : ''}.${extension}`
+        return `${group.replace(/\./g, '/').replace(/:/g, '/')}/${artifact}/${version}/${artifact}-${version}${classifier != null ? `-${classifier}` : ''}.${extension}`
     }
 
     public static mavenIdentifierToUrl(id: string, extension = 'jar'): URL {

--- a/src/util/MavenUtil.ts
+++ b/src/util/MavenUtil.ts
@@ -1,10 +1,17 @@
 import { normalize } from 'path'
 import { URL } from 'url'
 
+export interface MavenComponents {
+    group: string
+    artifact: string
+    version: string
+    classifier?: string
+    extension: string
+}
+
 export class MavenUtil {
 
-    public static readonly ID_REGEX = /(.+):(.+):([^@]+)()(?:@{1}(.+)$)?/
-    public static readonly ID_REGEX_WITH_CLASSIFIER = /(.+):(.+):(?:([^@]+)(?:-([a-zA-Z]+)))(?:@{1}(.+)$)?/
+    public static readonly ID_REGEX = /([^@:]+):([^@:]+):?([^@:]+)?:?(?:([^@:]+))?:?(?:@{1}([^@:]+))?/
 
     public static mavenComponentsToIdentifier(
         group: string,
@@ -16,35 +23,39 @@ export class MavenUtil {
         return `${group}:${artifact}:${version}${classifier != null ? `:${classifier}` : ''}${extension != null ? `@${extension}` : ''}`
     }
 
-    public static isMavenIdentifier(id: string): boolean {
-        return MavenUtil.ID_REGEX.test(id) || MavenUtil.ID_REGEX_WITH_CLASSIFIER.test(id)
+    public static mavenComponentsToExtensionlessIdentifier(
+        group: string,
+        artifact: string,
+        version: string,
+        classifier?: string
+    ): string {
+        return MavenUtil.mavenComponentsToIdentifier(group, artifact, version, classifier)
     }
 
-    public static getMavenComponents(id: string, extension = 'jar'): {
-        group: string
+    public static mavenComponentsToVersionlessIdentifier(
+        group: string,
         artifact: string
-        version: string
-        classifier?: string
-        extension: string
-    } {
+    ): string {
+        return `${group}:${artifact}`
+    }
+
+    public static isMavenIdentifier(id: string): boolean {
+        return MavenUtil.ID_REGEX.test(id)
+    }
+
+    public static getMavenComponents(id: string, extension = 'jar'): MavenComponents {
         if (!MavenUtil.isMavenIdentifier(id)) {
             throw new Error('Id is not a maven identifier.')
         }
 
-        let result
-
-        if (MavenUtil.ID_REGEX_WITH_CLASSIFIER.test(id)) {
-            result = MavenUtil.ID_REGEX_WITH_CLASSIFIER.exec(id)
-        } else {
-            result = MavenUtil.ID_REGEX.exec(id)
-        }
+        const result = MavenUtil.ID_REGEX.exec(id)
 
         if (result != null) {
             return {
                 group: result[1],
                 artifact: result[2],
                 version: result[3],
-                classifier: result[4] || undefined,
+                classifier: result[4],
                 extension: result[5] || extension
             }
         }
@@ -52,38 +63,38 @@ export class MavenUtil {
         throw new Error('Failed to process maven data.')
     }
 
-    public static mavenIdentifierToString(id: string, extension = 'jar'): string {
+    public static mavenIdentifierAsPath(id: string, extension = 'jar'): string {
         const tmp = MavenUtil.getMavenComponents(id, extension)
 
-        return MavenUtil.mavenComponentsToString(
+        return MavenUtil.mavenComponentsAsPath(
             tmp.group, tmp.artifact, tmp.version, tmp.classifier, tmp.extension
         )
     }
 
-    public static mavenComponentsToString(
+    public static mavenComponentsAsPath(
         group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): string {
-        return `${group.replace(/\./g, '/').replace(/:/g, '/')}/${artifact}/${version}/${artifact}-${version}${classifier != null ? `-${classifier}` : ''}.${extension}`
+        return `${group.replace(/\./g, '/')}/${artifact}/${version}/${artifact}-${version}${classifier != null ? `-${classifier}` : ''}.${extension}`
     }
 
     public static mavenIdentifierToUrl(id: string, extension = 'jar'): URL {
-        return new URL(MavenUtil.mavenIdentifierToString(id, extension))
+        return new URL(MavenUtil.mavenIdentifierAsPath(id, extension))
     }
 
     public static mavenComponentsToUrl(
         group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): URL {
-        return new URL(MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension))
+        return new URL(MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension))
     }
 
     public static mavenIdentifierToPath(id: string, extension = 'jar'): string {
-        return normalize(MavenUtil.mavenIdentifierToString(id, extension))
+        return normalize(MavenUtil.mavenIdentifierAsPath(id, extension))
     }
 
-    public static mavenComponentsToPath(
+    public static mavenComponentsAsNormalizedPath(
         group: string, artifact: string, version: string, classifier?: string, extension = 'jar'
     ): string {
-        return normalize(MavenUtil.mavenComponentsToString(group, artifact, version, classifier, extension))
+        return normalize(MavenUtil.mavenComponentsAsPath(group, artifact, version, classifier, extension))
     }
 
 }

--- a/src/util/MinecraftVersion.ts
+++ b/src/util/MinecraftVersion.ts
@@ -1,6 +1,6 @@
 export class MinecraftVersion {
 
-    private static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).(\d+)/
+    private static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).?(\d+)?/
 
     private readonly major: number
     private readonly minor: number
@@ -11,7 +11,7 @@ export class MinecraftVersion {
         if(res != null) {
             this.major = Number(res[1])
             this.minor = Number(res[2])
-            this.revision = Number(res[3])
+            this.revision = Number(res[3]) ?? undefined
         } else {
             throw new Error(`${version} is not a valid minecraft version!`)
         }
@@ -23,8 +23,8 @@ export class MinecraftVersion {
 
     public getMajor(): number { return this.major }
     public getMinor(): number { return this.minor }
-    public getRevision(): number { return this.revision }
+    public getRevision(): number|undefined { return this.revision }
 
-    public toString(): string { return `${this.major}.${this.minor}.${this.revision}`}
+    public toString(): string { return `${this.major}.${this.minor}${this.revision? '.'+this.revision:''}`}
 
 }

--- a/src/util/MinecraftVersion.ts
+++ b/src/util/MinecraftVersion.ts
@@ -4,14 +4,14 @@ export class MinecraftVersion {
 
     private readonly major: number
     private readonly minor: number
-    private readonly revision: number
+    private readonly revision: number | undefined
 
     constructor(version: string) {
         const res = MinecraftVersion.MINECRAFT_VERSION_REGEX.exec(version)
         if(res != null) {
             this.major = Number(res[1])
             this.minor = Number(res[2])
-            this.revision = Number(res[3]) ?? undefined
+            this.revision = res[3] != null ? Number(res[3]) : undefined
         } else {
             throw new Error(`${version} is not a valid minecraft version!`)
         }
@@ -23,8 +23,8 @@ export class MinecraftVersion {
 
     public getMajor(): number { return this.major }
     public getMinor(): number { return this.minor }
-    public getRevision(): number|undefined { return this.revision }
+    public getRevision(): number | undefined { return this.revision }
 
-    public toString(): string { return `${this.major}.${this.minor}${this.revision? '.'+this.revision:''}`}
+    public toString(): string { return `${this.major}.${this.minor}${this.revision != null ? '.' + this.revision : ''}`}
 
 }

--- a/src/util/VersionUtil.ts
+++ b/src/util/VersionUtil.ts
@@ -12,7 +12,7 @@ export class VersionUtil {
         'latest'
     ]
 
-    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).(\d+)/
+    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).?(\d+)?/
 
     public static isVersionAcceptable(version: MinecraftVersion, acceptable: number[]): boolean {
         if (version.getMajor() === 1) {

--- a/src/util/VersionUtil.ts
+++ b/src/util/VersionUtil.ts
@@ -12,7 +12,7 @@ export class VersionUtil {
         'latest'
     ]
 
-    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).?(\d+)?/
+    public static readonly MINECRAFT_VERSION_REGEX = /(\d+).(\d+).(\d+)?/
 
     public static isVersionAcceptable(version: MinecraftVersion, acceptable: number[]): boolean {
         if (version.getMajor() === 1) {


### PR DESCRIPTION
# Implements 1.20 support for Nebula, and allow Minecraft releases without revision number

## How to test:
Generate a server with 1.20, then a distribution, and upload it.
Launch it on Helios
This PR has been used for the default Helios distribution file url, and doesn't needs any update on the launcher side

![image](https://github.com/dscalzi/Nebula/assets/45696571/cd8d6416-2b05-43cc-832c-c84aeebbbd1f)
