### PR TITLE
⚙️ Improved modpacks compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ typings/
 .dynamodb/
 /.idea
 /root
+/html

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+/.idea
+/root

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ const initRootCommand: CommandModule = {
             await generateSchemas(argv.root as string)
             await new DistributionStructure(argv.root as string, '', false, false).init()
             await new CurseForgeParser(argv.root as string, '').init()
-            await new ModrinthParser(argv.root as string, '').init()
+            await new ModrinthParser(argv.root as string).init()
             logger.info(`Successfully created new root at ${argv.root}`)
         } catch (error) {
             logger.error(`Failed to init new root at ${argv.root}`, error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,9 @@ const generateServerModrinthCommand: CommandModule = {
         logger.debug(`Root set to ${argv.root}`)
         logger.debug(`Generating server ${argv.id} using Modrinth modpack ${argv.modpack} as a template.`)
 
-        const parser = new ModrinthParser(argv.root as string, argv.modpack as string)
+        const parser = new ModrinthParser(argv.root as string)
+        await parser.resolveModpackZip(argv.modpack as string)
+
         const modpackManifest = await parser.getModpackManifest()
 
         const minecraftVersion = new MinecraftVersion(modpackManifest.dependencies.minecraft)

--- a/src/parser/ModrinthParser.ts
+++ b/src/parser/ModrinthParser.ts
@@ -1,0 +1,126 @@
+// Based on CurseForgeParser.ts
+
+import { createWriteStream, lstatSync } from 'fs'
+import { opendir, rmdir } from 'fs/promises'
+import { mkdirs, move } from 'fs-extra/esm'
+import got from 'got'
+import StreamZip from 'node-stream-zip'
+import { join, resolve } from 'path'
+import { pipeline } from 'stream/promises'
+import { ToggleableNamespace } from '../structure/spec_model/module/ToggleableModule.struct.js'
+import { CreateServerResult } from '../structure/spec_model/Server.struct.js'
+import { LoggerUtil } from '../util/LoggerUtil.js'
+
+const log = LoggerUtil.getLogger('ModrinthParser')
+
+// No idea if this is right
+export interface ModrinthManifest {
+    game: string
+    formatVersion: number
+    versionId: string
+    name: string
+    summary: string // optional
+    files: {
+        path: string
+        hashes: {
+            sha1: string
+            sha512: string
+        }
+        env: {  // optional
+            client: string // required, optional or unsupported
+            server: string // required, optional or unsupported
+        }
+        downloads: string[]
+        fileSize: number 
+    }[]
+    dependencies: { // more dependency ids may be added in the future
+        minecraft: string
+        forge: string
+        neoforge: string
+        "fabric-loader": string
+        "quilt-loader": string
+    }
+}
+
+export class ModrinthParser {
+    private modpackDir: string
+    private zipPath: string
+
+    constructor(
+        private absoluteRoot: string,
+        private modpack: string
+    ) {
+        this.modpackDir = join(absoluteRoot, 'modpacks', 'modrinth')
+        this.zipPath = join(this.modpackDir, modpack) //TODO: add autodownload capabilities
+    }
+
+    public async init(): Promise<void> {
+        await mkdirs(this.modpackDir)
+    }
+
+    public async getModpackManifest(): Promise<ModrinthManifest> {
+        const zip = new StreamZip.async({ file: this.zipPath })
+        return JSON.parse((await zip.entryData('modrinth.index.json')).toString('utf8')) as ModrinthManifest
+    }
+
+    public async enrichServer(createServerResult: CreateServerResult, manifest: ModrinthManifest): Promise<void> {
+        log.debug('Enriching server.')
+
+        // Extract overrides
+        const zip = new StreamZip.async({ file: this.zipPath })
+        try {
+            await zip.extract("overrides/", createServerResult.miscFileContainer)
+        }
+        finally {
+            await zip.close()
+        }
+
+        if(createServerResult.modContainer) {
+            const requiredPath = resolve(createServerResult.modContainer, ToggleableNamespace.REQUIRED)
+            const optionalPath = resolve(createServerResult.modContainer, ToggleableNamespace.OPTIONAL_ON)
+
+            // Download mods
+            for(const file of manifest.files) {
+                // if client is unsupported, skip
+                if(file.env.client === 'unsupported') {
+                    log.warn(`Skipping unsupported mod: ${file.path.split("/").pop()}`)
+                    continue
+                }
+
+                // find the correct directory for this file
+                let ressource_path: string
+                if (file.path.startsWith("mods/")) {
+                    log.debug(`Processing - Mod: ${file.path.split("/").pop()}`)
+                    ressource_path = join(file.env.client == "required" ? requiredPath : optionalPath, file.path.split("/").pop()!)
+                } else {
+                    log.debug(`Processing - Resource: ${file.path.split("/").pop()}`)
+                    ressource_path = join(createServerResult.miscFileContainer, file.path)
+
+                    // ensure that the path exists
+                    await mkdirs(ressource_path.split("/").slice(0, -1).join("/") + "/")
+                }
+                
+                const downloadStream = got.stream(file.downloads[0])
+                const fileWriterStream = createWriteStream(ressource_path)
+
+                await pipeline(downloadStream, fileWriterStream)
+            }
+
+
+            // move overrided mods to the required folder
+            if(lstatSync(join(createServerResult.miscFileContainer, 'mods')).isDirectory()) {
+
+                // move every override mod to the required folder
+                const overrideMods = await opendir(join(createServerResult.miscFileContainer, 'mods'))
+                for await (const mod of overrideMods) {
+                    log.debug(`Moving ${mod.name}`)
+                    await move(join(createServerResult.miscFileContainer, 'mods', mod.name), join(requiredPath, mod.name), { overwrite: true })
+                }
+                
+                // delete the mods override folder
+                await rmdir(join(createServerResult.miscFileContainer, 'mods'))
+            }
+        }
+    }
+
+}

--- a/src/parser/ModrinthParser.ts
+++ b/src/parser/ModrinthParser.ts
@@ -83,7 +83,7 @@ export class ModrinthParser {
         log.debug('Resolving modpack zip.')
 
         // check if join(this.modpackDir, modpack) exists
-        if(existsSync(join(this.modpackDir, modpack))) {
+        if(existsSync(join(this.modpackDir, modpack)) && lstatSync(join(this.modpackDir, modpack)).isFile()) {
             this.zipPath = join(this.modpackDir, modpack)
         } else {
             log.debug('Unable to find the modpack zip.')
@@ -185,7 +185,7 @@ export class ModrinthParser {
 
 
             // move overrided mods to the required folder
-            if(lstatSync(join(createServerResult.miscFileContainer, 'mods')).isDirectory()) {
+            if(existsSync(join(createServerResult.miscFileContainer, 'mods')) && lstatSync(join(createServerResult.miscFileContainer, 'mods')).isDirectory()) {
 
                 // move every override mod to the required folder
                 const overrideMods = await opendir(join(createServerResult.miscFileContainer, 'mods'))


### PR DESCRIPTION
This PR introduces support for Fabric-based CurseForge modpacks and modpacks in the .mrpack format (Modrinth).

Only supports the Fabric and Forge based modpacks, other loaders such as neoforge or quilt are not currently supported.